### PR TITLE
Enhanced wallpaper anchoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+# 9.0.1 [Wallpaper Anchoring]
+
+- Updated the anchoring of various theme's wallpapers so that you can see your waifu!
+  - Be sure to re-install the stickers for this to take effect.
+
+| Before | After |
+| --- | --- |
+| ![Screenshot from 2021-02-20 06-10-01](https://user-images.githubusercontent.com/15972415/108594985-e14eb680-7342-11eb-8afc-09afe2bc9af0.png) | ![Screenshot from 2021-02-20 06-09-22](https://user-images.githubusercontent.com/15972415/108594986-e3187a00-7342-11eb-819c-30e49ea16cfe.png) |
+
 # 9.0.0 [Zero Two, Sakurajima Mai]
 
 ## 4 New Themes

--- a/buildSrc/BuildThemes.ts
+++ b/buildSrc/BuildThemes.ts
@@ -450,16 +450,19 @@ const getStickers = (
 ) => {
   const secondary =
     dokiDefinition.stickers.secondary || dokiDefinition.stickers.normal;
+  const backgrounds = dokiTheme.backgrounds;
   return {
     default: {
       path: resolveStickerPath(dokiTheme.path, dokiDefinition.stickers.default),
       name: dokiDefinition.stickers.default,
+      anchoring: backgrounds?.default?.anchor || "center",
     },
     ...(secondary
       ? {
           secondary: {
             path: resolveStickerPath(dokiTheme.path, secondary),
             name: secondary,
+            anchoring: backgrounds?.secondary?.anchor || "center",
           },
         }
       : {}),
@@ -582,7 +585,6 @@ walkDir(masterThemeTemplateDirectoryPath)
             "icons",
           ]),
           stickers: getStickers(dokiDefinition, dokiTheme),
-          ...(dokiTheme.backgrounds ? dokiTheme.backgrounds : {}),
         },
       };
     });

--- a/buildSrc/BuildThemes.ts
+++ b/buildSrc/BuildThemes.ts
@@ -112,6 +112,15 @@ interface Stickers {
   normal?: string;
 }
 
+interface BackgroundPositioning {
+  anchor: string;
+}
+
+interface BackgroundPositionings {
+  default?: BackgroundPositioning;
+  secondary?: BackgroundPositioning; 
+}
+
 export interface VSCodeDokiThemeDefinition {
   id: string;
   overrides: Overrides;
@@ -119,6 +128,7 @@ export interface VSCodeDokiThemeDefinition {
     extends: string;
     ui: StringDictonary<string>;
   };
+  backgrounds?: BackgroundPositionings;
   syntax: {};
   colors: {};
 }
@@ -369,6 +379,7 @@ function createDokiTheme(
     return {
       path: swapMasterThemeForLocalTheme(dokiFileDefinitionPath),
       definition: dokiThemeDefinition,
+      backgrounds: dokiThemeVSCodeDefinition.backgrounds,
       theme: buildVSCodeTheme(
         dokiThemeDefinition,
         dokiThemeVSCodeDefinition,
@@ -571,6 +582,7 @@ walkDir(masterThemeTemplateDirectoryPath)
             "icons",
           ]),
           stickers: getStickers(dokiDefinition, dokiTheme),
+          ...(dokiTheme.backgrounds ? dokiTheme.backgrounds : {}),
         },
       };
     });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "A bunch of themes with cute anime girls. Code with your waifu!",
   "publisher": "unthrottled",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/DokiTheme.ts
+++ b/src/DokiTheme.ts
@@ -24,4 +24,5 @@ export interface DokiSticker {
 export interface Sticker {
   path: string;
   name: string;
+  anchoring: string;
 }

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from "./VSCodeGlobals";
 import { attemptToGreetUser } from "./WelcomeService";
 
 const SAVED_VERSION = "doki.theme.version";
-const DOKI_THEME_VERSION = "v9.0.0";
+const DOKI_THEME_VERSION = "v9.0.1";
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
   const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -21,6 +21,7 @@ function getVsCodeCss() {
 function buildStickerCss({
   stickerDataURL: stickerUrl,
   backgroundImageURL: wallpaperUrl,
+  backgroundAnchoring,
 }: DokiStickers): string {
   const style =
     "content:'';pointer-events:none;position:absolute;z-index:9001;width:100%;height:100%;background-position:100% 97%;background-repeat:no-repeat;opacity:1;";
@@ -37,7 +38,7 @@ function buildStickerCss({
   /* Background Image */
   .monaco-workbench .part.editor > .content {
     background-image: url('${wallpaperUrl}') !important;
-    background-position: center;
+    background-position: ${backgroundAnchoring};
     background-size: cover;
     content:'';
     z-index:9001;
@@ -69,6 +70,7 @@ function canWrite(): boolean {
 export interface DokiStickers {
   stickerDataURL: string;
   backgroundImageURL: string;
+  backgroundAnchoring: string;
 }
 
 export async function installStickersAndWallPaper(

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -27,6 +27,7 @@ export const attemptToUpdateSticker = async (
     return {
       stickerDataURL: remoteStickerUrl,
       backgroundImageURL: remoteWallpaperUrl,
+      backgroundAnchoring: currentSticker.anchoring,
     };
   }
 
@@ -40,6 +41,7 @@ export const attemptToUpdateSticker = async (
   return {
     stickerDataURL: createCssDokiAssetUrl(localStickerPath),
     backgroundImageURL: createCssDokiAssetUrl(localWallpaperPath),
+    backgroundAnchoring: currentSticker.anchoring,
   };
 };
 

--- a/src/WelcomeService.ts
+++ b/src/WelcomeService.ts
@@ -34,17 +34,23 @@ export function attemptToGreetUser(context: vscode.ExtensionContext) {
                     You can choose themes from the following Doki-Doki Theme Suites such as:
                 </p>
                 <ul>
-                    <li>Doki-Doki Literature Club</li>
-                    <li>Re:Zero</li>
-                    <li>Kill La Kill</li>
-                    <li>KonoSuba</li>
+                    <li>Darling in the Franxx</li>
                     <li>DanganRonpa</li>
-                    <li>High School DxD</li>
-                    <li>Lucky Star</li>
-                    <li>Sword Art Online</li>
+                    <li>Doki-Doki Literature Club</li>
                     <li>Fate</li>
                     <li>Gate</li>
+                    <li>High School DxD</li>
+                    <li>Kill La Kill</li>
+                    <li>KonoSuba</li>
+                    <li>Live Live!</li>
+                    <li>Lucky Star</li>
                     <li>Miss Kobayashi's Dragon Maid</li>
+                    <li>Neon Genesis Evangelion</li>
+                    <li>OreGairu</li>
+                    <li>Re:Zero</li>
+                    <li>Rascal does not dream of bunny girl senpai</li>
+                    <li>Steins Gate</li>
+                    <li>Sword Art Online</li>
                 </ul>
                 <h2>Stickers!</h2>
                     <p>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import {attemptToUpdateSticker} from "./StickerUpdateService";
 export interface Sticker {
   path: string;
   name: string;
+  anchoring: string;
 }
 
 export interface DokiThemeDefinition {

--- a/themes/definitions/bunnySenpai/mai/dark/mai.dark.vsCode.definition.json
+++ b/themes/definitions/bunnySenpai/mai/dark/mai.dark.vsCode.definition.json
@@ -5,6 +5,11 @@
     "extends": "dark-contrast",
     "ui": {}
   },
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/bunnySenpai/mai/dark/mai.dark.vsCode.definition.json
+++ b/themes/definitions/bunnySenpai/mai/dark/mai.dark.vsCode.definition.json
@@ -6,7 +6,7 @@
     "ui": {}
   },
   "backgrounds": {
-    "default": {
+    "secondary": {
       "anchor": "right"
     }
   },

--- a/themes/definitions/bunnySenpai/mai/light/mai.light.vsCode.definition.json
+++ b/themes/definitions/bunnySenpai/mai/light/mai.light.vsCode.definition.json
@@ -3,7 +3,7 @@
   "overrides": {},
   "laf": {},
   "backgrounds": {
-    "default": {
+    "secondary": {
       "anchor": "right"
     }
   },

--- a/themes/definitions/bunnySenpai/mai/light/mai.light.vsCode.definition.json
+++ b/themes/definitions/bunnySenpai/mai/light/mai.light.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "98878c8e-9f91-4e25-930d-dd7d280d9e35",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {
     "selectionBackground":"#d3d5f1"

--- a/themes/definitions/danganronpa/ibuki/dark/ibuki.dark.vsCode.definition.json
+++ b/themes/definitions/danganronpa/ibuki/dark/ibuki.dark.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "420b0ed5-803c-4127-97e3-dae6aa1a5972",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/danganronpa/ibuki/light/ibuki.light.vsCode.definition.json
+++ b/themes/definitions/danganronpa/ibuki/light/ibuki.light.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "697e8564-0975-4907-a34c-51f65177ebf3",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/killLaKill/ryuko/ryuko.vsCode.definition.json
+++ b/themes/definitions/killLaKill/ryuko/ryuko.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "19b65ec8-133c-4655-a77b-13623d8e97d3",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/literature/natsuki/dark/natsuki.dark.vsCode.definition.json
+++ b/themes/definitions/literature/natsuki/dark/natsuki.dark.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "a7e0aa28-739a-4671-80ae-3980997e6b71",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/literature/natsuki/light/natsuki.light.vsCode.definition.json
+++ b/themes/definitions/literature/natsuki/light/natsuki.light.vsCode.definition.json
@@ -9,6 +9,11 @@
       "activityBar.background": "&headerColor&"
     }
   },
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/oreGairu/yukino/dark/yukino.dark.vsCode.definition.json
+++ b/themes/definitions/oreGairu/yukino/dark/yukino.dark.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "06143cbe-2d51-4423-9a93-73a02c828119",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/reZero/beatrice/beatrice.vsCode.definition.json
+++ b/themes/definitions/reZero/beatrice/beatrice.vsCode.definition.json
@@ -14,6 +14,11 @@
       "scrollbarSlider.activeBackground": "&accentColorSecondary&9A"
     }
   },
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/reZero/emilia/dark/emilia.dark.vsCode.definition.json
+++ b/themes/definitions/reZero/emilia/dark/emilia.dark.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "696de7c1-3a8e-4445-83ee-3eb7e9dca47f",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/reZero/emilia/light/emilia.light.vsCode.definition.json
+++ b/themes/definitions/reZero/emilia/light/emilia.light.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "e828aaae-aa8c-4084-8993-d64697146930",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/reZero/ram/ram.vsCode.definition.json
+++ b/themes/definitions/reZero/ram/ram.vsCode.definition.json
@@ -5,6 +5,11 @@
     "extends": "dark-contrast",
     "ui": {}
   },
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }

--- a/themes/definitions/reZero/rem/rem.vsCode.definition.json
+++ b/themes/definitions/reZero/rem/rem.vsCode.definition.json
@@ -2,6 +2,11 @@
   "id": "f770dcfc-f41e-4b49-aa17-66e9ffc208fd",
   "overrides": {},
   "laf": {},
+  "backgrounds": {
+    "default": {
+      "anchor": "right"
+    }
+  },
   "syntax": {},
   "colors": {}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Updated the anchoring of various theme's wallpapers so that you can see your waifu!
  - Be sure to re-install the stickers for this to take effect.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #44 

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

| Before | After |
| --- | --- |
| ![Screenshot from 2021-02-20 06-10-01](https://user-images.githubusercontent.com/15972415/108594985-e14eb680-7342-11eb-8afc-09afe2bc9af0.png) | ![Screenshot from 2021-02-20 06-09-22](https://user-images.githubusercontent.com/15972415/108594986-e3187a00-7342-11eb-819c-30e49ea16cfe.png) |

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I updated the version.
- [x] I updated the changelog with the new functionality.