### PR TITLE
v1.58.+ Content installation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 13.1.0 [Insiders Content Support]
+
+- Changed how stickers/wallpapers are installed, so they show up in VSCode v1.58.+. 
+Please re-run your sticker/wallpaper command to see the changes take effect.
+
 # 13.0.1 [Just trust me, bro]
 
 - Changed extension to be enabled in [restricted mode](https://code.visualstudio.com/docs/editor/workspace-trust#_restricted-mode).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "A bunch of themes with cute anime girls. Code with your waifu!",
   "publisher": "unthrottled",
-  "version": "13.0.1",
+  "version": "13.1.0",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from "./VSCodeGlobals";
 import { attemptToGreetUser } from "./WelcomeService";
 
 const SAVED_VERSION = "doki.theme.version";
-const DOKI_THEME_VERSION = "v13.0.1";
+const DOKI_THEME_VERSION = "v13.1.0";
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
   const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);

--- a/src/StickerUpdateService.ts
+++ b/src/StickerUpdateService.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { performGet } from "./RESTClient";
 import path from "path";
 import fs from "fs";
+import { URL } from 'url';
 import crypto from "crypto";
 import {
   VSCODE_ASSETS_URL,
@@ -13,6 +14,14 @@ import {
 } from "./ENV";
 import { DokiStickers } from "./StickerService";
 import { Sticker } from "./extension";
+
+function loadImageBase64FromFileProtocol(url: string): string {
+  const fileUrl = new URL(url);
+  const imageBuffer = fs.readFileSync(fileUrl);
+  const imageExtensionName = path.extname(fileUrl.pathname).substr(1);
+
+  return `data:image/${imageExtensionName};base64,${imageBuffer.toString('base64')}`;
+}
 
 export const forceUpdateSticker = async (
   context: vscode.ExtensionContext,
@@ -163,7 +172,7 @@ const resolveLocalBackgroundPath = (
 };
 
 const createCssDokiAssetUrl = (localAssetPath: string): string => {
-  return `file://${cleanPathToUrl(localAssetPath)}`;
+  return loadImageBase64FromFileProtocol(`file://${cleanPathToUrl(localAssetPath)}`);
 };
 
 function cleanPathToUrl(stickerPath: string) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Loading installed assets directly in place of referencing the local file.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Apparently VSCode folks decided to no longer allow access to local files :disappointed: 

Fixes #84 

Observed & Verified Fixed on

```
Version: 1.58.0-insider
Commit: e1161be26874f0d39a5b9cdeb2c5fbfd4f83bb80
Date: 2021-06-14T05:13:48.044Z
Electron: 12.0.9
Chrome: 89.0.4389.128
Node.js: 14.16.0
V8: 8.9.255.25-electron.0
OS: Linux x64 5.4.0-74-generic
```

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
