### PR TITLE
Added auto checksum fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 14.2.0 [Auto-Checksum Fix]
+
+- Plugin automatically fixes VSCode's checksums on bundled/custom asset installation/removal. Just close all instances of VSCode and start it back up to get rid of the annoying `Unsupported` error.
+
 # 14.1.1 [Settings UI Enhancement]
 
 - Updated the VSCode [Settings UI](https://code.visualstudio.com/docs/getstarted/settings) to support installed wallpapers!

--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ You can choose themes from various, Anime, Manga, or Visual Novels:
 **Background Wallpaper** is probably one of the best features of the plugin.
 This feature will set the background image to the current theme's official wallpaper.
 
-**Important!!** Installing theme assets requires me to corrupt VS-Code by modifying CSS. You will have to use the "Remove Sticker/Background" command to restore VS Code back to supported status before unistalling. 
-[This plugin](https://marketplace.visualstudio.com/items?itemName=lehni.vscode-fix-checksums) can remove the annoying `Unsupported` warning.
+**Important!!** Installing theme assets requires me to corrupt VS-Code by modifying CSS. You will have to use the "Remove Sticker/Background" command to restore VS Code back to supported status before unistalling. You can close VSCode and start it back up remove the annoying `Unsupported` warning. The plugin automatically fixes VSCode's checksums.
 
 **Glass Pane effect**
 
@@ -88,8 +87,7 @@ This feature will set the background image to the current theme's official wallp
 
 **Show sticker** allows you to control the presence of the cute sticker in the bottom right-hand corner of your IDE.
 
-**Important!!** Installing theme assets requires me to corrupt VS-Code by modifying CSS. You will have to use the "Remove Sticker/Background" command to restore VS Code back to supported status before unistalling.
-[This plugin](https://marketplace.visualstudio.com/items?itemName=lehni.vscode-fix-checksums) can remove the annoying `Unsupported` warning.
+**Important!!** Installing theme assets requires me to corrupt VS-Code by modifying CSS. You will have to use the "Remove Sticker/Background" command to restore VS Code back to supported status before unistalling. You can close VSCode and start it back up remove the annoying `Unsupported` warning. The plugin automatically fixes VSCode's checksums.
 
 ![Ibuki's Dark Sticker](./readmeStuff/sticker.png)
 
@@ -162,7 +160,7 @@ Applies for the following content:
 
 ## Remove Assets
 
-Removes both the sticker and wallpaper from your vscode and restores the supported status.
+Removes both the sticker and wallpaper from your vscode and restores the original supported status.
 
 ## Show Changelog
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "A bunch of themes with cute anime girls. Code with your waifu!",
   "publisher": "unthrottled",
-  "version": "14.1.1",
+  "version": "14.2.0",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {
@@ -802,21 +802,15 @@
         "uiTheme": "vs"
       },
       {
-        "id": "9a310731-ab2d-40f5-b502-fa5419f799a2",
-        "label": "Doki Theme: DDLC:  Monika",
-        "path": "./generatedThemes/Monika Light.theme.json",
-        "uiTheme": "vs"
-      },
-      {
         "id": "dce48196-ff46-470c-b5f9-d1e23f4a79d3",
         "label": "Doki Theme: DDLC:  Monika",
         "path": "./generatedThemes/Monika Dark.theme.json",
         "uiTheme": "vs-dark"
       },
       {
-        "id": "91415015-8fe3-48eb-9951-70a5cd6cbb7f",
-        "label": "Doki Theme: DDLC:  Natsuki",
-        "path": "./generatedThemes/Natsuki Light.theme.json",
+        "id": "9a310731-ab2d-40f5-b502-fa5419f799a2",
+        "label": "Doki Theme: DDLC:  Monika",
+        "path": "./generatedThemes/Monika Light.theme.json",
         "uiTheme": "vs"
       },
       {
@@ -824,6 +818,12 @@
         "label": "Doki Theme: DDLC:  Natsuki",
         "path": "./generatedThemes/Natsuki Dark.theme.json",
         "uiTheme": "vs-dark"
+      },
+      {
+        "id": "91415015-8fe3-48eb-9951-70a5cd6cbb7f",
+        "label": "Doki Theme: DDLC:  Natsuki",
+        "path": "./generatedThemes/Natsuki Light.theme.json",
+        "uiTheme": "vs"
       },
       {
         "id": "cb8ef4b7-0844-4a04-b08b-754086598de4",
@@ -838,16 +838,16 @@
         "uiTheme": "vs-dark"
       },
       {
-        "id": "cecf3f92-76d4-4f14-9a9c-3d558b6b3b68",
-        "label": "Doki Theme: DDLC:  Yuri",
-        "path": "./generatedThemes/Yuri Light.theme.json",
-        "uiTheme": "vs"
-      },
-      {
         "id": "a14733d6-8e15-4e75-b6b8-509f323e5b3b",
         "label": "Doki Theme: DDLC:  Yuri",
         "path": "./generatedThemes/Yuri Dark.theme.json",
         "uiTheme": "vs-dark"
+      },
+      {
+        "id": "cecf3f92-76d4-4f14-9a9c-3d558b6b3b68",
+        "label": "Doki Theme: DDLC:  Yuri",
+        "path": "./generatedThemes/Yuri Light.theme.json",
+        "uiTheme": "vs"
       },
       {
         "id": "b93ab4ea-ff96-4459-8fa2-0caae5bc7116",
@@ -880,15 +880,15 @@
         "uiTheme": "vs-dark"
       },
       {
-        "id": "ea9a13f6-fa7f-46a4-ba6e-6cefe1f55160",
-        "label": "Doki Theme: DxD:  Rias",
-        "path": "./generatedThemes/Rias Onyx.theme.json",
-        "uiTheme": "vs-dark"
-      },
-      {
         "id": "c5e92ad9-2fa0-491e-b92a-48ab92d13597",
         "label": "Doki Theme: DxD:  Rias",
         "path": "./generatedThemes/Rias Crimson.theme.json",
+        "uiTheme": "vs-dark"
+      },
+      {
+        "id": "ea9a13f6-fa7f-46a4-ba6e-6cefe1f55160",
+        "label": "Doki Theme: DxD:  Rias",
+        "path": "./generatedThemes/Rias Onyx.theme.json",
         "uiTheme": "vs-dark"
       },
       {
@@ -1066,16 +1066,16 @@
         "uiTheme": "vs-dark"
       },
       {
-        "id": "546e8fb8-6082-4ef5-a5e3-44790686f02f",
-        "label": "Doki Theme: SAO:  Asuna",
-        "path": "./generatedThemes/Asuna Light.theme.json",
-        "uiTheme": "vs"
-      },
-      {
         "id": "bac375a4-abb3-44d5-9bef-8039eb83fec0",
         "label": "Doki Theme: SAO:  Asuna",
         "path": "./generatedThemes/Asuna Dark.theme.json",
         "uiTheme": "vs-dark"
+      },
+      {
+        "id": "546e8fb8-6082-4ef5-a5e3-44790686f02f",
+        "label": "Doki Theme: SAO:  Asuna",
+        "path": "./generatedThemes/Asuna Light.theme.json",
+        "uiTheme": "vs"
       },
       {
         "id": "d39df813-8701-463b-a964-b8cb7714d1cc",

--- a/src/CheckSumService.ts
+++ b/src/CheckSumService.ts
@@ -1,0 +1,73 @@
+import path from "path";
+import vscode from "vscode";
+import fs from "fs";
+import crypto from "crypto";
+import { appDirectory, workbenchDirectory } from "./ENV";
+
+const productFile = path.join(appDirectory, "product.json");
+const originalProductFile = `${productFile}.orig.${vscode.version}`;
+
+const outDirectory = path.resolve(workbenchDirectory, '..', '..');
+
+export const fixCheckSums = () => {
+  const product: any = require(productFile);
+  const checksumChanged = Object.entries(product.checksums).reduce(
+    (didChange, entry) => {
+      const [filePath, currentChecksum] = entry;
+      const checksum = computeChecksum(
+        path.join(outDirectory, ...filePath.split("/"))
+      );
+      if (checksum !== currentChecksum) {
+        product.checksums[filePath] = checksum;
+        return true;
+      }
+
+      return didChange;
+    },
+    false
+  );
+
+  if (checksumChanged) {
+    const json = JSON.stringify(product, null, "\t");
+    try {
+      if (!fs.existsSync(originalProductFile)) {
+        fs.renameSync(productFile, originalProductFile);
+      }
+      fs.writeFileSync(productFile, json, { encoding: "utf8" });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+};
+
+export const restoreChecksum = () => {
+  try {
+    if (fs.existsSync(originalProductFile)) {
+      fs.unlinkSync(productFile);
+      fs.renameSync(originalProductFile, productFile);
+    }
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+function computeChecksum(file: string) {
+  const contents = fs.readFileSync(file);
+  return crypto
+    .createHash("md5")
+    .update(contents)
+    .digest("base64")
+    .replace(/=+$/, "");
+}
+
+export function cleanupOrigFiles() {
+  // Remove all old backup files that aren't related to the current version
+  // of VSCode anymore.
+  const oldOrigFiles = fs
+    .readdirSync(appDirectory)
+    .filter((file) => /\.orig\./.test(file))
+    .filter((file) => !file.endsWith(vscode.version));
+  for (const file of oldOrigFiles) {
+    fs.unlinkSync(path.join(appDirectory, file));
+  }
+}

--- a/src/ConfigWatcher.ts
+++ b/src/ConfigWatcher.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { fixCheckSums } from "./CheckSumService";
 import { InstallStatus } from "./StickerService";
 import { attemptToInstallSticker, attemptToInstallWallpaper, getCurrentThemeAndSticker, handleInstallFailure } from "./ThemeManager";
 
@@ -50,6 +51,7 @@ export const watchConfigChanges = (
         if (hadFailure) {
           handleInstallFailure(extensionContext, theme);
         } else if (hadSuccess) {
+          fixCheckSums();
           vscode.window
             .showInformationMessage(
               `Custom Assets installed!\n Please restart your VSCode`,

--- a/src/ENV.ts
+++ b/src/ENV.ts
@@ -44,3 +44,5 @@ export const CSS_COPY_FILE_NAME = `${CSS_FILE_NAME}.copy`;
 export const editorCss = path.join(workbenchDirectory, CSS_FILE_NAME);
 export const editorCssCopy = path.join(workbenchDirectory, CSS_COPY_FILE_NAME);
 
+export const appDirectory = path.resolve(workbenchDirectory, '..', '..', '..');
+

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from "./VSCodeGlobals";
 import { attemptToGreetUser } from "./WelcomeService";
 
 const SAVED_VERSION = "doki.theme.version";
-const DOKI_THEME_VERSION = "v14.1.1";
+const DOKI_THEME_VERSION = "v14.2.0";
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
   const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);

--- a/src/ThemeManager.ts
+++ b/src/ThemeManager.ts
@@ -14,6 +14,7 @@ import {
 } from "./SupportService";
 import DokiThemeDefinitions from "./DokiThemeDefinitions";
 import { DokiThemeDefinition, Sticker } from "./extension";
+import { fixCheckSums, restoreChecksum } from "./CheckSumService";
 
 export const ACTIVE_THEME = "doki.theme.active";
 
@@ -168,6 +169,7 @@ export function activateThemeAsset(
       VSCodeGlobals.globalState.update(ACTIVE_THEME, dokiTheme.id);
       VSCodeGlobals.globalState.update(ACTIVE_STICKER, currentSticker.type);
       StatusBarComponent.setText(dokiTheme.displayName);
+      fixCheckSums();
       vscode.window
         .showInformationMessage(
           `${dokiTheme.name}'s ${assetType} installed!\n Please restart your VSCode`,
@@ -202,6 +204,7 @@ export function uninstallImages(context: vscode.ExtensionContext) {
     stickersRemoved === InstallStatus.INSTALLED ||
     stickersRemoved === InstallStatus.NOT_INSTALLED
   ) {
+    restoreChecksum();
     vscode.window
       .showInformationMessage(
         `Removed Images. Please restart your restored VSCode`,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import {attemptToNotifyUpdates} from "./NotificationService";
 import {showChanglog} from "./ChangelogService";
 import {attemptToUpdateSticker} from "./StickerUpdateService";
 import { watchConfigChanges } from "./ConfigWatcher";
+import { cleanupOrigFiles as cleanupCheckSumRestorationFiles } from "./CheckSumService";
 
 export interface Sticker {
   path: string;
@@ -99,6 +100,8 @@ export function activate(context: vscode.ExtensionContext) {
     .forEach((disposableHero) => context.subscriptions.push(disposableHero));
 
     context.subscriptions.push(watchConfigChanges(context));
+
+    cleanupCheckSumRestorationFiles();
 }
 
 export function deactivate() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Plugin automatically fixes VSCode's checksums on bundled/custom asset installation/removal. Just close all instances of VSCode and start it back up to get rid of the annoying `Unsupported` error.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #93 


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
