### PR TITLE
Updated modal window styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Stylized the secondary button in the VS Code modal window to match the theme.
 
-![Just Trust Me, Bro]()
+![Just Trust Me, Bro](https://user-images.githubusercontent.com/15972415/129116241-f24404dd-2cb7-4858-8a0b-034e5d914b78.gif)
 
 # 15.0.0 [NekoPara OneeSan Vol.]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 15.0.1 [Modal Window Enhancement]
+
+- Stylized the secondary button in the VS Code modal window to match the theme.
+
+![Just Trust Me, Bro]()
+
 # 15.0.0 [NekoPara OneeSan Vol.]
 
 ## 4 New Themes!!

--- a/buildSrc/assets/templates/base.laf.template.json
+++ b/buildSrc/assets/templates/base.laf.template.json
@@ -130,6 +130,8 @@
     "activityBar.inactiveForeground": "&accentColor&BB",
     "button.background": "&buttonColor&",
     "button.foreground": "&buttonFont&",
+    "button.secondaryForeground":"&buttonFont&BB",
+    "button.secondaryBackground":"&buttonColor&CC",
     "editor.lineHighlightBackground": "&caretRow&77",
     "gitlens.trailingLineBackgroundColor": "&caretRow&77",
     "editor.lineHighlightBorder": "&caretRow&00",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "A bunch of themes with cute anime girls. Code with your waifu!",
   "publisher": "unthrottled",
-  "version": "15.0.0",
+  "version": "15.0.1",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from "./VSCodeGlobals";
 import { attemptToGreetUser } from "./WelcomeService";
 
 const SAVED_VERSION = "doki.theme.version";
-const DOKI_THEME_VERSION = "v15.0.0";
+const DOKI_THEME_VERSION = "v15.0.1";
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
   const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Stylized the secondary button in the VS Code modal window to match the theme.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Was getting really annoyed with the `Do you trust this project` modal having a not themed button.

#### Screenshots (if appropriate):

![Peek 2021-08-11 18-16_smol_2](https://user-images.githubusercontent.com/15972415/129116241-f24404dd-2cb7-4858-8a0b-034e5d914b78.gif)


#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [X] I updated the changelog with the new functionality.
