### PR TITLE
Better Sticker Z-Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Placing the sticker at the proper z-index such that it no longer blocks the: Notifications & Status Bar Tooltips. Please re-install your sticker for this to take effect!
 
+![Can See Notifications Now](https://user-images.githubusercontent.com/15972415/194716630-1ffe84f7-b20b-4403-8e24-e7eea37b3754.png)
+
 # 88.1-1.3.0 [Darling]
 
 Best Girl just got _better_. ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 88.1.3.1 [Sticker Z-Index Fix]
+
+- Placing the sticker at the proper z-index such that it no longer blocks the: Notifications & Status Bar Tooltips. Please re-install your sticker for this to take effect!
+
 # 88.1-1.3.0 [Darling]
 
 Best Girl just got _better_. ❤️

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "The Doki Theme",
   "description": "Cute anime character themes!",
   "publisher": "unthrottled",
-  "version": "88.1.7",
+  "version": "88.1.8",
   "license": "MIT",
   "icon": "Doki-Theme.png",
   "galleryBanner": {

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from "./VSCodeGlobals";
 import { attemptToGreetUser } from "./WelcomeService";
 
 const SAVED_VERSION = "doki.theme.version";
-const DOKI_THEME_VERSION = "v88.1-1.3.0";
+const DOKI_THEME_VERSION = "v88.1-1.3.1";
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
   const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -152,7 +152,7 @@ function buildBackgroundCss({
 function buildStickerCss({ stickerDataURL: stickerUrl }: DokiStickers): string {
   const stickerPositioningStyles: string = vscode.workspace.getConfiguration(CONFIG_NAME).get(CONFIG_STICKER_CSS) + '';
   const style =
-    "content:'';pointer-events:none;position:absolute;z-index:9001;width:100%;height:100%;background-repeat:no-repeat;opacity:1;"
+    "content:'';pointer-events:none;position:absolute;z-index:10;width:100%;height:100%;background-repeat:no-repeat;opacity:1;"
     + stickerPositioningStyles + (stickerPositioningStyles.endsWith(';') ? '':';') ;
   return `
   ${stickerComment}
@@ -161,6 +161,7 @@ function buildStickerCss({ stickerDataURL: stickerUrl }: DokiStickers): string {
   {background-image: url('${stickerUrl}');${style}}
 
   /* Makes sure notification shows on top of sticker */
+  .monaco-workbench>.notifications-center,
   .notifications-toasts {
     z-index: 9002 !important;
   }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Placing the sticker at the proper z-index such that it no longer blocks the: Notifications & Status Bar Tooltips. 

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #176

#### Screenshots (if appropriate):
<img width="485" alt="Screen Shot 2022-10-08 at 10 53 45 AM" src="https://user-images.githubusercontent.com/15972415/194716630-1ffe84f7-b20b-4403-8e24-e7eea37b3754.png">

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I updated the version.
- [x] I updated the changelog with the new functionality.
