### PR TITLE
Restored Hide Watermark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 88.3-1.5.2 [Hide Watermark Restore]
+
+- Restored hide watermark functionality for VSCode 1.75.0.
+
 ## 88.3-1.5.1 [Terminal Wallpaper Bugfix]
 
 - Fixed wallpaper rendering issue terminals of VSCode 1.74.3. Please re-install your wallpaper for this to take effect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 88.3-1.5.2 [Hide Watermark Restore]
 
-- Restored hide watermark functionality for VSCode 1.75.0.
+- Restored hide watermark functionality for VSCode 1.75.0. Please re-run the hide watermark command for this to take effect.
+
+![Hidden Watermark](https://user-images.githubusercontent.com/15972415/216770850-7dc66024-78f5-4503-ae15-2dc087def6cd.png)
 
 ## 88.3-1.5.1 [Terminal Wallpaper Bugfix]
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Doki Theme",
   "description": "Cute anime character themes!",
   "publisher": "unthrottled",
-  "version": "88.1.12",
+  "version": "88.1.13",
   "license": "MIT",
   "icon": "Doki-Theme-v2.png",
   "galleryBanner": {

--- a/src/NotificationService.ts
+++ b/src/NotificationService.ts
@@ -3,7 +3,7 @@ import { VSCodeGlobals } from "./VSCodeGlobals";
 import { attemptToGreetUser } from "./WelcomeService";
 
 const SAVED_VERSION = "doki.theme.version";
-const DOKI_THEME_VERSION = "v88.3-1.5.1";
+const DOKI_THEME_VERSION = "v88.3-1.5.2";
 
 export function attemptToNotifyUpdates(context: vscode.ExtensionContext) {
   const savedVersion = VSCodeGlobals.globalState.get(SAVED_VERSION);

--- a/src/StickerService.ts
+++ b/src/StickerService.ts
@@ -178,6 +178,8 @@ function buildHideWaterMarkCSS(): string {
   return `
   ${hideComment}
   .monaco-workbench .part.editor.has-watermark>.content.empty .editor-group-container>.editor-group-letterpress,
+  .part.editor>.content .editor-group-container .editor-group-watermark>.letterpress,
+  .monaco-workbench .part.editor>.content .editor-group-container>.editor-group-watermark>.shortcuts>.watermark-box,
   .monaco-workbench .part.editor>.content.empty>.watermark>.watermark-box 
   {
     display: none !important;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
- Restored hide watermark functionality for VSCode 1.75.0

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
- They broked it
#### Screenshots (if appropriate):

| Before | After |
| --- | --- |
| <img width="1142" alt="Screenshot 2023-02-04 at 7 32 19 AM" src="https://user-images.githubusercontent.com/15972415/216770843-ecbcc421-cd4b-40d4-bf02-8dcb56fa2697.png"> | <img width="1142" alt="Screenshot 2023-02-04 at 7 31 52 AM" src="https://user-images.githubusercontent.com/15972415/216770850-7dc66024-78f5-4503-ae15-2dc087def6cd.png"> |

#### Types of changes
<!-- What types jhJof changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes . -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I updated the version.
- [x] I updated the changelog with the new functionality.
